### PR TITLE
Improve SPI flash support

### DIFF
--- a/client/GoodFETSPI.py
+++ b/client/GoodFETSPI.py
@@ -313,6 +313,16 @@ class GoodFETSPIFlash(GoodFETSPI):
         self.writecmd(0x01,0x03,
                       len(adranddata),adranddata);
         
+    def SPIerasesector(self,adr):
+        #24 bits, BE, not 32 bits, LE.
+        adranddata=[adr&0xFF,
+                    (adr&0xFF00)>>8,
+                    (adr&0xFF0000)>>16,
+                    0, #MSB
+                    ];
+        self.writecmd(0x01,0x86,
+                      len(adranddata),adranddata);
+
     def SPIchiperase(self):
         """Mass erase an SPI Flash ROM."""
         self.writecmd(0x01,0x81);

--- a/client/goodfet.spiflash
+++ b/client/goodfet.spiflash
@@ -19,6 +19,7 @@ if(len(sys.argv)==1):
     print "%s info" % sys.argv[0];
     print "%s dump $foo.rom [0x$start 0x$stop]" % sys.argv[0];
     print "%s erase" % sys.argv[0];
+    print "%s erasesector 0x$start" % sys.argv[0];
     print "%s flash $foo.rom [0x$start 0x$stop]" % sys.argv[0];
     print "%s verify $foo.rom [0x$start 0x$stop]" % sys.argv[0];
     print "%s peek 0x$start [0x$stop]" % sys.argv[0];
@@ -166,6 +167,11 @@ if(sys.argv[1]=="flash"):
 
 if(sys.argv[1]=="erase"):
   client.SPIchiperase();
+
+if(sys.argv[1]=="erasesector"):
+    start=int(sys.argv[2],16);
+    print "Erasing sector at %06x" % (start);
+    client.SPIerasesector(start)
 
 if(sys.argv[1]=="peek"):
     start=0x0000;

--- a/firmware/apps/spi/spi.c
+++ b/firmware/apps/spi/spi.c
@@ -433,6 +433,11 @@ void spi_handle_fn( uint8_t const app,
 		txdata(app,verb,0);
 		break;
 
+	case SPI_ERASE_SECTOR:
+		spiflash_erasesector(cmddatalong[0]);
+		txdata(app,verb,0);
+		break;
+
 	case SPI_ERASE://Erase the SPI Flash ROM.
 		spiflash_wrten();
 		CLRSS; //Drop !SS to begin transaction.

--- a/firmware/include/command.h
+++ b/firmware/include/command.h
@@ -65,6 +65,7 @@ extern unsigned char silent;
 #define SPI_ZENSYS_ENABLE 0x83
 #define SPI_ZENSYS_WRITE3_READ1 0x84
 #define SPI_ZENSYS_WRITE2_READ2 0x85
+#define SPI_ERASE_SECTOR 0x86
 
 //OCT commands
 #define OCT_CMP 0x90


### PR DESCRIPTION
Some little improvements to SPI flash support.
Most importantly, writing to the flash no longer overwrites the status register, removing all write protections.

And add sector erase.
