### PR TITLE
Call callable descriptors in USBInterface.get_descriptor

### DIFF
--- a/client/USBInterface.py
+++ b/client/USBInterface.py
@@ -89,7 +89,10 @@ class USBInterface:
         if self.iclass:
             iclass_desc_num = USB.interface_class_to_descriptor_type(self.iclass)
             if iclass_desc_num:
-                d += self.descriptors[iclass_desc_num]
+                desc = self.descriptors[iclass_desc_num]
+                if callable(desc):
+                    desc = desc(self.iclass)
+                d += desc
 
         for e in self.endpoints:
             d += e.get_descriptor()


### PR DESCRIPTION
For some reason there is no check if the descriptor is callable when it is added to the full descriptor in ``USBInterface.get_descriptor`` which causes Facedancer to fail when provided with handlers and not descriptor strings.