### PR TITLE
Fix CCSPI TX ignore last byte

### DIFF
--- a/firmware/apps/radios/ccspi.c
+++ b/firmware/apps/radios/ccspi.c
@@ -552,7 +552,7 @@ void ccspi_handle_fn( uint8_t const app,
     //Load the packet.
     CLRSS;
     ccspitrans8(CCSPI_TXFIFO);
-    for(i=0;i<cmddata[0];i++)
+    for(i=0;i<len;i++)
       ccspitrans8(cmddata[i]);
     SETSS;
 


### PR DESCRIPTION
The CCSPI app had a bug in CCSPI_TX verb, it used the frame length field
as the length of the entire packet to send. However, according to
802.15.4 spec it's the length of the payload not including the one byte
header (see http://www.ti.com/lit/ds/symlink/cc2420.pdf 16.2 - Length
Field).
This bug is fixed by using the length provided in the message and not
the first byte of cmddata.

To verify the fix -
1. Turn off autocrc
2. Send a packet
3. Peek the TX_FIFO (RAM[0x0:0x80])
4. Ensure all bytes of the packet are in the TX_FIFO