### PR TITLE
Fix CCSPI pokeram functionality

### DIFF
--- a/client/GoodFETCCSPI.py
+++ b/client/GoodFETCCSPI.py
@@ -19,6 +19,7 @@ class GoodFETCCSPI(GoodFET):
         
         #Set up the radio for ZigBee
         self.strobe(0x01);       #SXOSCON
+        self.strobe(0x01);       #SXOSCON ## YL: idk why but needed to enable ram poking
         self.strobe(0x02);       #SCAL
         self.poke(0x11, 0x0AC2 & (~0x0800)); #MDMCTRL0, promiscuous
         self.poke(0x12, 0x0500); #MDMCTRL1

--- a/firmware/apps/radios/ccspi.c
+++ b/firmware/apps/radios/ccspi.c
@@ -155,7 +155,7 @@ void ccspireflexjam(u16 delay){
 }
 
 //! Writes bytes into the CC2420's RAM.  Untested.
-void ccspi_pokeram(u8 addr, u8 *data, int len){
+void ccspi_pokeram(u16 addr, u8 *data, int len){
   CLRSS;
   //Begin with the start address.
   ccspitrans8(0x80 | (addr & 0x7F)); 


### PR DESCRIPTION
* Fix a bug in ccspi_pokeram wrong address parameter type
* Add double strobing of SXOSCON upon setup

I have no idea WHY the second item is needed but poking the RAM doesn't
work without it ¯\_(ツ)_/¯

cc @rmspeers 