### PR TITLE
Force Python version for scripts that depend on it

### DIFF
--- a/client/goodfet
+++ b/client/goodfet
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # GoodFET Debugger
 # 
 # (C) 2009 Travis Goodspeed <travis at radiantmachines.com>

--- a/client/goodfet.adc
+++ b/client/goodfet.adc
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """
 ADC10 client (currently only supports x2274 chip, on the GoodFET31
 board, where pin 5 of JTAG header is sampled.)

--- a/client/goodfet.arm7
+++ b/client/goodfet.arm7
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import struct

--- a/client/goodfet.arm9
+++ b/client/goodfet.arm9
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import struct

--- a/client/goodfet.at91sam7s
+++ b/client/goodfet.at91sam7s
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import struct

--- a/client/goodfet.at91sam9g20
+++ b/client/goodfet.at91sam9g20
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import struct

--- a/client/goodfet.at91x40
+++ b/client/goodfet.at91x40
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import struct

--- a/client/goodfet.avr
+++ b/client/goodfet.avr
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys;
 import binascii;

--- a/client/goodfet.bsl
+++ b/client/goodfet.bsl
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Serial Bootstrap Loader software for the MSP430 embedded proccessor.
 #
 # (C) 2001-2003 Chris Liechti <cliechti@gmx.net>

--- a/client/goodfet.bslold
+++ b/client/goodfet.bslold
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Serial Bootstrap Loader software for the MSP430 embedded proccessor.
 #
 # (C) 2001-2003 Chris Liechti <cliechti@gmx.net>

--- a/client/goodfet.bslv2
+++ b/client/goodfet.bslv2
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import hidapi
 import struct

--- a/client/goodfet.cc
+++ b/client/goodfet.cc
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # GoodFET Chipcon Example
 # 
 # (C) 2009 Travis Goodspeed <travis at radiantmachines.com>

--- a/client/goodfet.cc2500
+++ b/client/goodfet.cc2500
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #GoodFET Chipcon CC2500 SPI Client
 #by Jean-Michel Picod <jean-michel.picod at cassidan.com>

--- a/client/goodfet.ccspi
+++ b/client/goodfet.ccspi
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #GoodFET Chipcon SPI Client
 # (C) 2011 Travis Goodspeed

--- a/client/goodfet.donbL
+++ b/client/goodfet.donbL
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # A simple python client to speak to the donbL AVR boot loader
 # donb (donb@capitolhillconsultants.com)

--- a/client/goodfet.em260
+++ b/client/goodfet.em260
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #GoodFET SPI Flash Client
 #by Travis Goodspeed

--- a/client/goodfet.glitch
+++ b/client/goodfet.glitch
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys,binascii,time,random;
 

--- a/client/goodfet.i2ceeprom
+++ b/client/goodfet.i2ceeprom
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #GoodFET I2C eeprom Client
 

--- a/client/goodfet.jtag
+++ b/client/goodfet.jtag
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # GoodFET Basic JTAG
 # 
 # (C) 2009 Travis Goodspeed <travis at radiantmachines.com>

--- a/client/goodfet.maxusb
+++ b/client/goodfet.maxusb
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #GoodFET MAXIM MAX3421 and MAX3420 Client
 #by Travis Goodspeed

--- a/client/goodfet.maxusbdfu
+++ b/client/goodfet.maxusbdfu
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #DFU USB Device Emulator
 #by Travis Goodspeed

--- a/client/goodfet.maxusbftdi
+++ b/client/goodfet.maxusbftdi
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #FTDI USB Device Emulator
 #by Travis Goodspeed

--- a/client/goodfet.maxusbhid
+++ b/client/goodfet.maxusbhid
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #GoodFET MAXIM MAX3421 and MAX3420 Client
 #by Travis Goodspeed

--- a/client/goodfet.maxusbhost
+++ b/client/goodfet.maxusbhost
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #GoodFET MAXIM MAX3421 Host
 #by Travis Goodspeed

--- a/client/goodfet.maxusbmass
+++ b/client/goodfet.maxusbmass
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #USB Mass Storage Emulator
 #by Travis Goodspeed

--- a/client/goodfet.mcpcan
+++ b/client/goodfet.mcpcan
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # GoodFET SPI Flash Client
 #
 # (C) 2012 Travis Goodspeed <travis at radiantmachines.com>

--- a/client/goodfet.monitor
+++ b/client/goodfet.monitor
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys;
 import binascii;

--- a/client/goodfet.msp430
+++ b/client/goodfet.msp430
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys;
 import binascii;

--- a/client/goodfet.nrf
+++ b/client/goodfet.nrf
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #GoodFET SPI Flash Client
 #by Travis Goodspeed

--- a/client/goodfet.owe
+++ b/client/goodfet.owe
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys;
 import binascii;

--- a/client/goodfet.pic
+++ b/client/goodfet.pic
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # PIC client (currently only supports dsPIC33F/PIC24H.)
 #
 # Note that a verify operation only considers addresses specified in

--- a/client/goodfet.rf
+++ b/client/goodfet.rf
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #GoodFET SPI Flash Client
 #by Travis Goodspeed

--- a/client/goodfet.slc2
+++ b/client/goodfet.slc2
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # GoodFET - Silicon Lab C2
 

--- a/client/goodfet.spi
+++ b/client/goodfet.spi
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #GoodFET Raw SPI Client
 #by Sebastien F4GRX <f4grx@f4grx.net>

--- a/client/goodfet.spi25c
+++ b/client/goodfet.spi25c
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #GoodFET SPI Flash Client
 #by Travis Goodspeed

--- a/client/goodfet.spiflash
+++ b/client/goodfet.spiflash
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #GoodFET SPI Flash Client
 #by Travis Goodspeed

--- a/client/goodfet.twe
+++ b/client/goodfet.twe
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # GoodFET - Atmel 2-wire EEPROM
 

--- a/client/goodfet.xscale
+++ b/client/goodfet.xscale
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # GoodFET Intel XScale
 # 
 # (C) 2009 Travis Goodspeed <travis at radiantmachines.com>

--- a/client/goodfet.zensys
+++ b/client/goodfet.zensys
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #GoodFET Zensys SPI flash interface
 #by Jean-Michel Picod

--- a/client/goodfet.zigduino
+++ b/client/goodfet.zigduino
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #GoodFET zigduino client
 #forked from code by neighbor Travis Goodspeed by bx
 

--- a/firmware/gen_apps
+++ b/firmware/gen_apps
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/firmware/gen_builddate_h
+++ b/firmware/gen_builddate_h
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import datetime


### PR DESCRIPTION
GoodFET seems to rely on Python 2, but some of the included scripts have the shebang as `#!/usr/bin/env python`, which causes problems on systems where `python` defaults to Python 3. This changes the shebangs to explicitly reference Python 2.