### PR TITLE
Fix KiCad link for GIMME

### DIFF
--- a/hardware/targets/gimme/README.txt
+++ b/hardware/targets/gimme/README.txt
@@ -2,4 +2,4 @@ GIMME, a GoodFET/IM-Me programming interface
 
 contributed by Michael Ossmann <mike@ossmann.com>
 
-designed with KiCad: http://www.kicad-pcb.org
+designed with KiCad: https://www.kicad.org/


### PR DESCRIPTION
The previous link went to http://www.kicad-pcb.org/ which now seems to point to some weird gaming site? The official link is kicad.org.